### PR TITLE
when failing to parse xml, raise custom exception with original document

### DIFF
--- a/lib/ajims/lti.rb
+++ b/lib/ajims/lti.rb
@@ -40,6 +40,7 @@ module AJIMS # :nodoc:
   end
 end
 
+require 'ajims/lti/exceptions'
 require 'ajims/lti/extensions'
 require 'ajims/lti/launch_params'
 require 'ajims/lti/request_validator'

--- a/lib/ajims/lti/exceptions.rb
+++ b/lib/ajims/lti/exceptions.rb
@@ -1,0 +1,15 @@
+module AJIMS::LTI
+  class XmlParseException < StandardError
+    attr_reader :original_exception, :content
+    def initialize(content, msg = "Failed to parse XML")
+      super(msg)
+      @content = content
+    end
+
+    def to_s
+      error = super
+      error << "\nDOCUMENT:\n#{@content}\nEND OF DOCUMENT\n"
+      error
+    end
+  end
+end

--- a/lib/ajims/lti/outcome_response.rb
+++ b/lib/ajims/lti/outcome_response.rb
@@ -117,6 +117,11 @@ module AJIMS::LTI
       @operation = doc.text("//imsx_statusInfo/imsx_operationRefIdentifier")
       @score = doc.text("//readResultResponse//resultScore/textString")
       @score = @score.to_s if @score
+    rescue REXML::ParseException
+      raise AJIMS::LTI::XmlParseException.new(
+        xml,
+        "Failed to parse XML response from canvas"
+      )
     end
 
     # Generate XML based on the current configuration

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -90,4 +90,20 @@ describe AJIMS::LTI::OutcomeResponse do
     res.generate_response_xml.should == alt
   end
 
+  it "should raise an exception if the xml is invalid" do
+    html = <<-HTML
+<html>
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+</body>
+</html>
+HTML
+
+    res = AJIMS::LTI::OutcomeResponse.new
+    expect { res.process_xml(html) }.to raise_exception(AJIMS::LTI::XmlParseException) do |ex|
+      expect(ex.content).to eq(html)
+    end
+  end
 end


### PR DESCRIPTION
for easier debugging