### PR TITLE
Update oauth dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 gemspec
 
-gem "oauth",   "~>0.5.5"
+gem "oauth",   "~>1.1.0"
 gem "builder"
 gem 'uuid'
 

--- a/aj-ims-lti.gemspec
+++ b/aj-ims-lti.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'aj-ims-lti'
-  s.version = '1.2.1'
+  s.version = '1.3.0'
 
   s.add_dependency 'builder'
   s.add_dependency 'oauth', '>= 0.6.0', '< 1.2'

--- a/aj-ims-lti.gemspec
+++ b/aj-ims-lti.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = '1.2.1'
 
   s.add_dependency 'builder'
-  s.add_dependency 'oauth', '~> 0.5.10'
+  s.add_dependency 'oauth', '>= 0.6.0', '< 1.2'
   s.add_dependency 'uuid'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
There is no need to lock to specific oauth gem versions. The only breaking changes in oauth 1.x are to remove support for older rubies.